### PR TITLE
Work for empty defaults.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,10 +22,12 @@ class postgrey::config() {
     }
   }
 
-  concat::fragment { 'postgrey/whitelist_clients':
-    target  => '/etc/postgrey/whitelist_clients',
-    order   => 15,
-    content => inline_template('<%= scope.lookupvar("postgrey::whitelist_clients").join("\n") %>')
+  if ($postgrey::whitelist_clients != []) {
+    concat::fragment { 'postgrey/whitelist_clients':
+      target  => '/etc/postgrey/whitelist_clients',
+      order   => 15,
+      content => inline_template('<%= scope.lookupvar("postgrey::whitelist_clients").join("\n") %>')
+    }
   }
 
   concat {
@@ -46,10 +48,12 @@ class postgrey::config() {
     }
   }
 
-  concat::fragment { 'postgrey/whitelist_recipients':
-    target  => '/etc/postgrey/whitelist_recipients',
-    order   => 15,
-    content => inline_template('<%= scope.lookupvar("postgrey::whitelist_recipients").join("\n") %>')
+  if ($postgrey::whitelist_recipients != []) {
+    concat::fragment { 'postgrey/whitelist_recipients':
+      target  => '/etc/postgrey/whitelist_recipients',
+      order   => 15,
+      content => inline_template('<%= scope.lookupvar("postgrey::whitelist_recipients").join("\n") %>')
+    }
   }
 }
 


### PR DESCRIPTION
Fixes
Critical: Scope(Concat::Fragment[postgrey/whitelist_clients]): No content, sourc
e or symlink specified

for me.

Alternative fix was to add \n after the join to make sure it's never
empty.