### PR TITLE
add parameters for whitelist files

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,10 +2,10 @@
 #
 # Parameters:
 # $whitelist_clients_file:
-#   path of the whitelist_clients file.
+#   path of the whitelist_clients file to create.
 #   default: '/etc/postgrey/whitelist_clients'
 # $whitelist_receipients_file:
-#   path of the whitelist_recepients file.
+#   path of the whitelist_recepients file to create
 #   default: '/etc/postgrey/whitelist_recipients'
 #
 class postgrey::config(

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,22 +1,35 @@
-class postgrey::config() {
+# Class to configure whitelists
+#
+# Parameters:
+# $whitelist_clients_file:
+#   path of the whitelist_clients file.
+#   default: '/etc/postgrey/whitelist_clients'
+# $whitelist_receipients_file:
+#   path of the whitelist_recepients file.
+#   default: '/etc/postgrey/whitelist_recipients'
+#
+class postgrey::config(
+  $whitelist_clients_file     = '/etc/postgrey/whitelist_clients',
+  $whitelist_receipients_file = '/etc/postgrey/whitelist_recipients',
+) {
   file {
     '/etc/default/postgrey':
       content => template('postgrey/default.erb');
   }
 
   concat {
-    '/etc/postgrey/whitelist_clients':
+    $whitelist_clients_file:
   }
 
   concat::fragment { 'postgrey/whitelist_clients/header':
-     target => '/etc/postgrey/whitelist_clients',
+     target => $whitelist_clients_file,
      order  => 00,
      source => 'puppet:///modules/postgrey/whitelist_clients.header';
   }
 
   if ($postgrey::default_whitelist_clients == true) {
     concat::fragment { 'postgrey/whitelist_clients/default':
-      target => '/etc/postgrey/whitelist_clients',
+      target => $whitelist_clients_file,
       order  => 10,
       source => 'puppet:///modules/postgrey/whitelist_clients.default';
     }
@@ -24,25 +37,25 @@ class postgrey::config() {
 
   if ($postgrey::whitelist_clients != []) {
     concat::fragment { 'postgrey/whitelist_clients':
-      target  => '/etc/postgrey/whitelist_clients',
+      target  => $whitelist_clients_file,
       order   => 15,
       content => inline_template('<%= scope.lookupvar("postgrey::whitelist_clients").join("\n") %>')
     }
   }
 
   concat {
-    '/etc/postgrey/whitelist_recipients':
+    $whitelist_receipients_file:
   }
 
   concat::fragment { 'postgrey/whitelist_recipients/header':
-     target => '/etc/postgrey/whitelist_recipients',
+     target => $whitelist_receipients_file,
      order  => 00,
      source => 'puppet:///modules/postgrey/whitelist_recipients.header';
   }
 
   if ($postgrey::default_whitelist_recipients == true) {
     concat::fragment { 'postgrey/whitelist_recipients/default':
-      target => '/etc/postgrey/whitelist_recipients',
+      target => $whitelist_receipients_file,
       order  => 10,
       source => 'puppet:///modules/postgrey/whitelist_recipients.default';
     }
@@ -50,7 +63,7 @@ class postgrey::config() {
 
   if ($postgrey::whitelist_recipients != []) {
     concat::fragment { 'postgrey/whitelist_recipients':
-      target  => '/etc/postgrey/whitelist_recipients',
+      target  => $whitelist_receipients_file,
       order   => 15,
       content => inline_template('<%= scope.lookupvar("postgrey::whitelist_recipients").join("\n") %>')
     }


### PR DESCRIPTION
this config parameter allows the configuration of the whitelist
file to use. This is useful if you do not want to overwrite
the default packaged whitelist files and use the .local files.